### PR TITLE
Update render method to create root

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom';
 import App from './components/App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+
+
+createRoot(document.getElementById('root')).render(<App />);


### PR DESCRIPTION
In this PR, an update is done to change ReactDOM.render method to createRoot method since it is deprecated, and not the recommended approach.